### PR TITLE
Add symlink_files to external docker config

### DIFF
--- a/cmd/grove/commands/init.go
+++ b/cmd/grove/commands/init.go
@@ -235,8 +235,11 @@ func filterProfileForExternalDocker(profile *detect.ProjectProfile, ext *config.
 	for _, s := range ext.SymlinkDirs {
 		symlinkSet[s] = true
 	}
-	copySet := make(map[string]bool, len(ext.CopyFiles))
+	copySet := make(map[string]bool, len(ext.CopyFiles)+len(ext.SymlinkFiles))
 	for _, f := range ext.CopyFiles {
+		copySet[f] = true
+	}
+	for _, f := range ext.SymlinkFiles {
 		copySet[f] = true
 	}
 

--- a/examples/config-external-docker.toml
+++ b/examples/config-external-docker.toml
@@ -84,6 +84,12 @@ services = ["app", "worker", "vite"]
 # Optional.
 copy_files = [".env", "config/master.key"]
 
+# Files to symlink from the main worktree on grove new.
+# Unlike copy_files, changes to the source propagate instantly.
+# Ideal for shared credentials that never diverge across worktrees.
+# Optional.
+symlink_files = ["config/credentials/development.key", "config/credentials/test.key"]
+
 # Directories to symlink from the main worktree into each new worktree on
 # `grove new`. Saves disk space for large directories like node_modules or
 # vendor/bundle. Paths are relative to the worktree root.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -92,13 +92,14 @@ type DockerPluginConfig struct {
 // ExternalComposeConfig configures external Docker Compose mode where services
 // are defined in a shared compose setup outside the project directory.
 type ExternalComposeConfig struct {
-	Path        string            `toml:"path"`         // Path to external compose directory
-	EnvVar      string            `toml:"env_var"`      // Environment variable name (e.g., "APP_DIR")
-	EnvFile     string            `toml:"env_file"`     // File to write env vars to (default: ".env")
-	Services    []string          `toml:"services"`     // Service names to manage
-	CopyFiles   []string          `toml:"copy_files"`   // Files to copy from main on worktree create
-	SymlinkDirs []string          `toml:"symlink_dirs"` // Directories to symlink from main on create
-	Agent       *AgentStackConfig `toml:"agent"`        // Optional agent stack configuration
+	Path         string            `toml:"path"`          // Path to external compose directory
+	EnvVar       string            `toml:"env_var"`       // Environment variable name (e.g., "APP_DIR")
+	EnvFile      string            `toml:"env_file"`      // File to write env vars to (default: ".env")
+	Services     []string          `toml:"services"`      // Service names to manage
+	CopyFiles    []string          `toml:"copy_files"`    // Files to copy from main on worktree create
+	SymlinkFiles []string          `toml:"symlink_files"` // Files to symlink from main on create
+	SymlinkDirs  []string          `toml:"symlink_dirs"`  // Directories to symlink from main on create
+	Agent        *AgentStackConfig `toml:"agent"`         // Optional agent stack configuration
 }
 
 // EnvFileName returns the configured env file name, defaulting to ".env".

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -608,6 +608,59 @@ symlink_dirs = ["vendor/bundle"]
 	}
 }
 
+func TestLoadExternalDockerConfig_WithSymlinkFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	composePath := filepath.Join(tmpDir, "shared-infra")
+	if err := os.MkdirAll(composePath, 0755); err != nil {
+		t.Fatalf("Failed to create compose dir: %v", err)
+	}
+
+	configData := `
+[plugins.docker]
+enabled = true
+mode = "external"
+
+[plugins.docker.external]
+path = "` + composePath + `"
+env_var = "APP_DIR"
+services = ["app"]
+copy_files = ["config/settings.local.yml"]
+symlink_files = ["config/credentials/development.key", "config/credentials/test.key"]
+symlink_dirs = ["vendor/bundle"]
+`
+	configPath := filepath.Join(tmpDir, "config.toml")
+	if err := os.WriteFile(configPath, []byte(configData), 0644); err != nil {
+		t.Fatalf("Failed to write config: %v", err)
+	}
+
+	cfg, err := LoadConfigFromPath(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfigFromPath() error = %v", err)
+	}
+
+	ext := cfg.Plugins.Docker.External
+	if ext == nil {
+		t.Fatal("Expected External config to be non-nil")
+	}
+	if len(ext.CopyFiles) != 1 {
+		t.Errorf("Expected 1 copy_files entry, got %d", len(ext.CopyFiles))
+	}
+	if len(ext.SymlinkFiles) != 2 {
+		t.Errorf("Expected 2 symlink_files entries, got %d", len(ext.SymlinkFiles))
+	}
+	if len(ext.SymlinkFiles) >= 2 {
+		if ext.SymlinkFiles[0] != "config/credentials/development.key" {
+			t.Errorf("Expected first symlink_files to be 'config/credentials/development.key', got %q", ext.SymlinkFiles[0])
+		}
+		if ext.SymlinkFiles[1] != "config/credentials/test.key" {
+			t.Errorf("Expected second symlink_files to be 'config/credentials/test.key', got %q", ext.SymlinkFiles[1])
+		}
+	}
+	if len(ext.SymlinkDirs) != 1 {
+		t.Errorf("Expected 1 symlink_dirs entry, got %d", len(ext.SymlinkDirs))
+	}
+}
+
 func TestMergeConfigsExternalDocker(t *testing.T) {
 	boolTrue := true
 

--- a/plugins/docker/README.md
+++ b/plugins/docker/README.md
@@ -237,6 +237,7 @@ symlink_dirs = [
 | `env_file` | No | Filename in the compose directory where grove writes the `env_var` value (default: `.env`). For example, with `env_var = "APP_DIR"` and `env_file = ".env.local"`, grove writes `APP_DIR=/abs/path/to/worktree` to `.env.local` and passes `--env-file .env.local` to compose. Set to `.env.local` to avoid dirtying a git-tracked `.env`. See [Env File Loaders](#env-file-loaders-direnv--mise) for optional loader setup. |
 | `services` | Yes | List of service names to manage |
 | `copy_files` | No | Files to copy from main worktree on `grove new` |
+| `symlink_files` | No | Files to symlink from main worktree on `grove new` (changes propagate instantly) |
 | `symlink_dirs` | No | Directories to symlink from main worktree on `grove new` |
 
 ### Defaults

--- a/plugins/docker/agent_external.go
+++ b/plugins/docker/agent_external.go
@@ -306,6 +306,20 @@ func setupWorktreeFiles(ext *config.ExternalComposeConfig, newPath, mainPath str
 		fmt.Fprintf(os.Stderr, "  copied %s\n", relPath)
 	}
 
+	for _, relPath := range ext.SymlinkFiles {
+		src := filepath.Join(mainPath, relPath)
+		dst := filepath.Join(newPath, relPath)
+
+		if err := createSymlink(src, dst); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: failed to symlink %s: %v\n", relPath, err)
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		fmt.Fprintf(os.Stderr, "  symlinked %s\n", relPath)
+	}
+
 	for _, relPath := range ext.SymlinkDirs {
 		src := filepath.Join(mainPath, relPath)
 		dst := filepath.Join(newPath, relPath)

--- a/plugins/docker/agent_external_test.go
+++ b/plugins/docker/agent_external_test.go
@@ -635,6 +635,118 @@ func TestHasActiveAgentSlot_NoAgentConfig(t *testing.T) {
 	}
 }
 
+func TestSetupWorktreeFiles_SymlinkFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	mainPath := filepath.Join(tmpDir, "main")
+	_ = os.MkdirAll(filepath.Join(mainPath, "config", "credentials"), 0755)
+	_ = os.WriteFile(filepath.Join(mainPath, "config", "credentials", "dev.key"), []byte("devkey"), 0600)
+
+	newPath := filepath.Join(tmpDir, "worktree")
+	_ = os.MkdirAll(newPath, 0755)
+
+	ext := &config.ExternalComposeConfig{
+		SymlinkFiles: []string{"config/credentials/dev.key"},
+	}
+
+	err := setupWorktreeFiles(ext, newPath, mainPath)
+	if err != nil {
+		t.Fatalf("setupWorktreeFiles() error = %v", err)
+	}
+
+	// Verify it's a symlink, not a copy
+	dst := filepath.Join(newPath, "config", "credentials", "dev.key")
+	info, err := os.Lstat(dst)
+	if err != nil {
+		t.Fatalf("Failed to stat symlinked file: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Error("Expected config/credentials/dev.key to be a symlink")
+	}
+
+	// Verify content is accessible through the symlink
+	data, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("Failed to read through symlink: %v", err)
+	}
+	if string(data) != "devkey" {
+		t.Errorf("Expected 'devkey', got %q", string(data))
+	}
+}
+
+func TestSetupWorktreeFiles_AllThreeTypes(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	mainPath := filepath.Join(tmpDir, "main")
+	_ = os.MkdirAll(filepath.Join(mainPath, "config"), 0755)
+	_ = os.WriteFile(filepath.Join(mainPath, "config", "settings.yml"), []byte("settings"), 0644)
+	_ = os.WriteFile(filepath.Join(mainPath, "config", "secret.key"), []byte("secret"), 0600)
+	_ = os.MkdirAll(filepath.Join(mainPath, "vendor", "bundle"), 0755)
+
+	newPath := filepath.Join(tmpDir, "worktree")
+	_ = os.MkdirAll(newPath, 0755)
+
+	ext := &config.ExternalComposeConfig{
+		CopyFiles:    []string{"config/settings.yml"},
+		SymlinkFiles: []string{"config/secret.key"},
+		SymlinkDirs:  []string{"vendor/bundle"},
+	}
+
+	err := setupWorktreeFiles(ext, newPath, mainPath)
+	if err != nil {
+		t.Fatalf("setupWorktreeFiles() error = %v", err)
+	}
+
+	// Verify copied file is a regular file
+	copyInfo, err := os.Lstat(filepath.Join(newPath, "config", "settings.yml"))
+	if err != nil {
+		t.Fatalf("Failed to stat copied file: %v", err)
+	}
+	if copyInfo.Mode()&os.ModeSymlink != 0 {
+		t.Error("Expected config/settings.yml to be a regular file (copy), not a symlink")
+	}
+
+	// Verify symlinked file
+	fileInfo, err := os.Lstat(filepath.Join(newPath, "config", "secret.key"))
+	if err != nil {
+		t.Fatalf("Failed to stat symlinked file: %v", err)
+	}
+	if fileInfo.Mode()&os.ModeSymlink == 0 {
+		t.Error("Expected config/secret.key to be a symlink")
+	}
+
+	// Verify symlinked directory
+	dirInfo, err := os.Lstat(filepath.Join(newPath, "vendor", "bundle"))
+	if err != nil {
+		t.Fatalf("Failed to stat symlinked dir: %v", err)
+	}
+	if dirInfo.Mode()&os.ModeSymlink == 0 {
+		t.Error("Expected vendor/bundle to be a symlink")
+	}
+}
+
+func TestSetupWorktreeFiles_SymlinkFiles_MissingSource(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	mainPath := filepath.Join(tmpDir, "main")
+	_ = os.MkdirAll(mainPath, 0755)
+
+	newPath := filepath.Join(tmpDir, "worktree")
+	_ = os.MkdirAll(newPath, 0755)
+
+	ext := &config.ExternalComposeConfig{
+		SymlinkFiles: []string{"nonexistent.key"},
+	}
+
+	err := setupWorktreeFiles(ext, newPath, mainPath)
+	if err == nil {
+		t.Error("Expected error for missing source file, got nil")
+	}
+	if !strings.Contains(err.Error(), "source not found") {
+		t.Errorf("Expected 'source not found' in error, got %q", err.Error())
+	}
+}
+
 func TestPlugin_RegisterHooks_IncludesPreRemove(t *testing.T) {
 	plugin := New()
 	cfg := &config.Config{}

--- a/plugins/docker/external.go
+++ b/plugins/docker/external.go
@@ -351,7 +351,7 @@ func copyFile(src, dst string) error {
 // as needed. If dst already exists and is a symlink, it is replaced.
 func createSymlink(src, dst string) error {
 	if _, err := os.Stat(src); err != nil {
-		return fmt.Errorf("source directory not found: %w", err)
+		return fmt.Errorf("source not found: %w", err)
 	}
 
 	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {


### PR DESCRIPTION
## Summary

- Adds `symlink_files` option to `[plugins.docker.external]` config, sitting between `copy_files` and `symlink_dirs`
- Symlinks are better than copies for shared credentials that never diverge across worktrees — single source of truth, instant `op` refresh propagation, and broken symlinks surface errors immediately
- Updates `grove init` filter to treat `symlink_files` entries as "handled" (prevents duplicate hooks.toml entries)
- Fixes `createSymlink` error message from "source directory not found" to "source not found" since it now handles files too

## Test plan

- [x] `make lint` passes
- [x] `make test` passes — all existing + 4 new tests
- [ ] Manual: create a config with `symlink_files`, run `grove new`, verify files are symlinks (`ls -la`)